### PR TITLE
Add `makeRange()` helper method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,3 @@ language: node_js
 node_js:
   - '10'
   - '8'
-  - '6'

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,8 @@
 export interface Options {
 	/**
-	 * A preferred port or an array of preferred ports to use.
+	 * A preferred port or an iterable of preferred ports to use.
 	 */
-	readonly port?: number | ReadonlyArray<number>,
+	readonly port?: number | Iterable<number>,
 
 	/**
 	 * The host on which port resolution should be performed. Can be either an IPv4 or IPv6 address.
@@ -19,12 +19,12 @@ declare const getPort: {
   (options?: Options): Promise<number>;
 
   /**
-   * Make a range of ports [from,to).
-   * @param from - First port of range(inclusive)
-   * @param to - Last port of range(exclusive)
-   * @returns Array with ports in range.
+   * Make a range of ports [from,to].
+   * @param from - First port of range, must be in range [1024,65535]
+   * @param to - Last port of range, must be in range [1024,65535], must be greater than `from`
+   * @returns Iterable of ports in range.
    */
-  makeRange(from: number, to: number): number[];
+  makeRange(from: number, to: number): Iterable<number>;
 }
 
 export default getPort;

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,9 +10,20 @@ export interface Options {
 	readonly host?: string;
 }
 
-/**
- * Get an available TCP port number.
- *
- * @returns Port number.
- */
-export default function getPort(options?: Options): Promise<number>;
+declare const getPort: {
+  /**
+   * Get an available TCP port number.
+   *
+   * @returns Port number.
+   */
+  (options?: Options): Promise<number>;
+
+  /**
+   * Make a range of ports [from,to).
+   *
+   * @returns Array with ports in range.
+   */
+  makeRange(from: number, to: number): number[];
+}
+
+export default getPort;

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,10 +19,11 @@ declare const getPort: {
   (options?: Options): Promise<number>;
 
   /**
-   * Make a range of ports [`from`,`to`].
-   * @param from - First port of range, must be in range [1024,65535]
-   * @param to - Last port of range, must be in range [1024,65535], must be greater than `from`
-   * @returns Iterable of ports in range.
+   * Make a range of ports `from...to`.
+   *
+   * @param from - First port of the range. Must be in the range `1024...65535`.
+   * @param to - Last port of the range. Must be in the range `1024...65535` and must be greater than `from`.
+   * @returns The ports in the range.
    */
   makeRange(from: number, to: number): Iterable<number>;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,7 +19,7 @@ declare const getPort: {
   (options?: Options): Promise<number>;
 
   /**
-   * Make a range of ports [from,to].
+   * Make a range of ports [`from`,`to`].
    * @param from - First port of range, must be in range [1024,65535]
    * @param to - Last port of range, must be in range [1024,65535], must be greater than `from`
    * @returns Iterable of ports in range.

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,7 +20,8 @@ declare const getPort: {
 
   /**
    * Make a range of ports [from,to).
-   *
+   * @param from - First port of range(inclusive)
+   * @param to - Last port of range(exclusive)
    * @returns Array with ports in range.
    */
   makeRange(from: number, to: number): number[];

--- a/index.js
+++ b/index.js
@@ -22,9 +22,7 @@ module.exports = async options => {
 
 	const portGenerator = function * (ports) {
 		if (ports) {
-			for (const port of ports) {
-				yield port;
-			}
+			yield * ports;
 		}
 
 		yield 0; // Fall back to 0 if anything else failed

--- a/index.js
+++ b/index.js
@@ -32,4 +32,21 @@ module.exports = options => options ?
 	getPort(options).catch(() => getPort(Object.assign(options, {port: 0}))) :
 	getPort({port: 0});
 
+module.exports.makeRange = (from, to) => {
+	if (!Number.isInteger(from) || !Number.isInteger(to) || from <= 1024 || to <= 1024 || from > 65535 || to > 65535) {
+		throw new TypeError('`from` and `to` port numbers must be integers in range (1023,65535]');
+	}
+
+	if (from > to) {
+		throw new Error('`from` port must be less than or equal to `to` port');
+	}
+
+	const ports = [];
+	for (let port = from; port < to; port++) {
+		ports.push(port);
+	}
+
+	return ports;
+};
+
 module.exports.default = module.exports;

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ module.exports = async options => {
 	let ports = null;
 
 	if (options) {
-		ports = (typeof options.port === 'number') ? [options.port] : options.port;
+		ports = typeof options.port === 'number' ? [options.port] : options.port;
 	}
 
 	for (const port of portCheckSequence(ports)) {
@@ -38,7 +38,7 @@ module.exports = async options => {
 		}
 	}
 
-	throw new Error('no available ports found');
+	throw new Error('No available ports found');
 };
 
 module.exports.makeRange = (from, to) => {

--- a/index.js
+++ b/index.js
@@ -13,30 +13,28 @@ const getAvailablePort = options => new Promise((resolve, reject) => {
 	});
 });
 
-const getAvailablePortFromIterable = async (ports, options) => {
-	for (const port of ports) {
-		const gotPort = await getAvailablePort(Object.assign({}, options, {port})); // eslint-disable-line no-await-in-loop
-		if (gotPort !== null) {
-			return gotPort;
-		}
-	}
-
-	return null;
-};
-
 module.exports = async options => {
-	if (options && options.port) {
-		const ports = (typeof options.port === 'number') ? [options.port] : options.port;
+	let ports = null;
 
-		const gotPort = await getAvailablePortFromIterable(ports, options);
+	if (options) {
+		ports = (typeof options.port === 'number') ? [options.port] : options.port;
+	}
+
+	const portGenerator = function * (ports) {
+		if (ports) {
+			for (const port of ports) {
+				yield port;
+			}
+		}
+
+		yield 0; // Fall back to 0 if anything else failed
+	};
+
+	for (const port of portGenerator(ports)) {
+		const gotPort = await getAvailablePort({...options, port}); // eslint-disable-line no-await-in-loop
 		if (gotPort !== null) {
 			return gotPort;
 		}
-	}
-
-	const gotPort = await getAvailablePort(Object.assign({}, options, {port: 0}));
-	if (gotPort !== null) {
-		return gotPort;
 	}
 
 	throw new Error('no available ports found');

--- a/index.js
+++ b/index.js
@@ -33,12 +33,20 @@ module.exports = options => options ?
 	getPort({port: 0});
 
 module.exports.makeRange = (from, to) => {
-	if (!Number.isInteger(from) || !Number.isInteger(to) || from <= 1024 || to <= 1024 || from > 65535 || to > 65535) {
-		throw new TypeError('`from` and `to` port numbers must be integers in range (1023,65535]');
+	if (!Number.isInteger(from) || !Number.isInteger(to)) {
+		throw new TypeError('`from` and `to` must ne integer numbers');
 	}
 
-	if (from > to) {
-		throw new Error('`from` port must be less than or equal to `to` port');
+	if (from < 1025 || from > 65535) {
+		throw new RangeError('`from` must be between 1025 and 65535');
+	}
+
+	if (to < 1025 || to > 65535) {
+		throw new RangeError('`to` must be between 1025 and 65535');
+	}
+
+	if (from >= to) {
+		throw new RangeError('`to` must be greater than `from`');
 	}
 
 	const ports = [];

--- a/index.js
+++ b/index.js
@@ -13,6 +13,14 @@ const getAvailablePort = options => new Promise((resolve, reject) => {
 	});
 });
 
+const portCheckSequence = function * (ports) {
+	if (ports) {
+		yield * ports;
+	}
+
+	yield 0; // Fall back to 0 if anything else failed
+};
+
 module.exports = async options => {
 	let ports = null;
 
@@ -20,15 +28,7 @@ module.exports = async options => {
 		ports = (typeof options.port === 'number') ? [options.port] : options.port;
 	}
 
-	const portGenerator = function * (ports) {
-		if (ports) {
-			yield * ports;
-		}
-
-		yield 0; // Fall back to 0 if anything else failed
-	};
-
-	for (const port of portGenerator(ports)) {
+	for (const port of portCheckSequence(ports)) {
 		const gotPort = await getAvailablePort({...options, port}); // eslint-disable-line no-await-in-loop
 		if (gotPort !== null) {
 			return gotPort;

--- a/index.js
+++ b/index.js
@@ -41,8 +41,8 @@ module.exports.makeRange = (from, to) => {
 		throw new RangeError('`from` must be between 1025 and 65535');
 	}
 
-	if (to < 1025 || to > 65535) {
-		throw new RangeError('`to` must be between 1025 and 65535');
+	if (to < 1025 || to > 65536) {
+		throw new RangeError('`to` must be between 1025 and 65536');
 	}
 
 	if (from >= to) {

--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ module.exports.makeRange = (from, to) => {
 	}
 
 	const generator = function * (from, to) {
-		for (let port = from; port < to; port++) {
+		for (let port = from; port <= to; port++) {
 			yield port;
 		}
 	};

--- a/index.js
+++ b/index.js
@@ -13,24 +13,33 @@ const getAvailablePort = options => new Promise((resolve, reject) => {
 	});
 });
 
+const getAvailablePortFromIterable = async (ports, options) => {
+	for (const port of ports) {
+		const gotPort = await getAvailablePort(Object.assign({}, options, {port})); // eslint-disable-line no-await-in-loop
+		if (gotPort !== null) {
+			return gotPort;
+		}
+	}
+
+	return null;
+};
+
 module.exports = async options => {
 	if (options && options.port) {
 		const ports = (typeof options.port === 'number') ? [options.port] : options.port;
 
-		for (const port of ports) {
-			const gotPort = await getAvailablePort(Object.assign({}, options, {port})); // eslint-disable-line no-await-in-loop
-			if (gotPort !== null) {
-				return gotPort;
-			}
+		const gotPort = await getAvailablePortFromIterable(ports, options);
+		if (gotPort !== null) {
+			return gotPort;
 		}
 	}
 
 	const gotPort = await getAvailablePort(Object.assign({}, options, {port: 0}));
-	if (gotPort === null) {
-		throw new Error('no available ports found');
+	if (gotPort !== null) {
+		return gotPort;
 	}
 
-	return gotPort;
+	throw new Error('no available ports found');
 };
 
 module.exports.makeRange = (from, to) => {

--- a/index.js
+++ b/index.js
@@ -34,15 +34,15 @@ module.exports = options => options ?
 
 module.exports.makeRange = (from, to) => {
 	if (!Number.isInteger(from) || !Number.isInteger(to)) {
-		throw new TypeError('`from` and `to` must ne integer numbers');
+		throw new TypeError('`from` and `to` must be integer numbers');
 	}
 
-	if (from < 1025 || from > 65535) {
-		throw new RangeError('`from` must be between 1025 and 65535');
+	if (from < 1024 || from > 65535) {
+		throw new RangeError('`from` must be between 1024 and 65535');
 	}
 
-	if (to < 1025 || to > 65536) {
-		throw new RangeError('`to` must be between 1025 and 65536');
+	if (to < 1024 || to > 65536) {
+		throw new RangeError('`to` must be between 1024 and 65536');
 	}
 
 	if (from >= to) {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -6,4 +6,4 @@ expectType<number>(await getPort({port: 3000}));
 expectType<number>(await getPort({port: [3000, 3001, 3002]}));
 expectType<number>(await getPort({host: 'https://localhost'}));
 
-expectType<number[]>(await getPort.makeRange(1025, 1026));
+expectType<number[]>(getPort.makeRange(1024, 1025));

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -6,4 +6,4 @@ expectType<number>(await getPort({port: 3000}));
 expectType<number>(await getPort({port: [3000, 3001, 3002]}));
 expectType<number>(await getPort({host: 'https://localhost'}));
 
-expectType<number[]>(getPort.makeRange(1024, 1025));
+expectType<Iterable<number>>(getPort.makeRange(1024, 1025));

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -5,3 +5,5 @@ expectType<number>(await getPort());
 expectType<number>(await getPort({port: 3000}));
 expectType<number>(await getPort({port: [3000, 3001, 3002]}));
 expectType<number>(await getPort({host: 'https://localhost'}));
+
+expectType<number[]>(await getPort.makeRange(1025, 1026));

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"url": "sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=6"
+		"node": ">=8"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd-check"

--- a/readme.md
+++ b/readme.md
@@ -72,7 +72,8 @@ The host on which port resolution should be performed. Can be either an IPv4 or 
 
 ### getPort.makeRange(from, to)
 
-Returns an `Iterable` range of ports
+Make a range of ports [`from`,`to`].
+Returns an `Iterable` of ports in range
 
 #### from
 

--- a/readme.md
+++ b/readme.md
@@ -39,12 +39,12 @@ Pass in an array of preferred ports:
 })();
 ```
 
-Use `makeRange` helper in case you need to select port from a range to generate an array of ports:
+Use the `makeRange()` helper in case you need a port in a certain range:
 
 ```js
 (async () => {
   console.log(await getPort({port: getPort.makeRange(3000, 3100)}));
-  // Will use any port >= 3000, port <= 3100, otherwise fall back to a random port
+  // Will use any port from 3000 to 3100, otherwise fall back to a random port
 })();
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,15 @@ Pass in an array of preferred ports:
 })();
 ```
 
+Use `makeRange` in case you need to select port from a range:
+
+```js
+(async () => {
+  console.log(await getPort({port: getPort.makeRange(3000, 3003)}));
+  // Will use any port >= 3000, port < 3003, otherwise fall back to a random port
+})();
+```
+
 ## API
 
 ### getPort([options])

--- a/readme.md
+++ b/readme.md
@@ -72,20 +72,21 @@ The host on which port resolution should be performed. Can be either an IPv4 or 
 
 ### getPort.makeRange(from, to)
 
-Make a range of ports [`from`,`to`].
-Returns an `Iterable` of ports in range
+Make a range of ports `from...to`.
+
+Returns an `Iterable` for ports in the given range.
 
 #### from
 
 Type: `number`
 
-First port of range, must be in range [1024,65535]
+First port of range. Must be in the range `1024...65535`.
 
 #### to
 
 Type: `number`
 
-Last port of range, must be in range [1024,65535], must be greater than `from`
+Last port of range. Must be in the range `1024...65535` and must be greater than `from`.
 
 
 ## Beware

--- a/readme.md
+++ b/readme.md
@@ -60,9 +60,9 @@ Type: `Object`
 
 ##### port
 
-Type: `number | number[]`
+Type: `number | Iterable<number>`
 
-A preferred port or an array of preferred ports to use.
+A preferred port or an iterable of preferred ports to use.
 
 ##### host
 
@@ -72,17 +72,19 @@ The host on which port resolution should be performed. Can be either an IPv4 or 
 
 ### getPort.makeRange(from, to)
 
+Returns an `Iterable` range of ports
+
 #### from
 
 Type: `number`
 
-Port to start range from, inclusive.
+First port of range, must be in range [1024,65535]
 
 #### to
 
 Type: `number`
 
-Port to end range at, exclusive.
+Last port of range, must be in range [1024,65535], must be greater than `from`
 
 
 ## Beware

--- a/readme.md
+++ b/readme.md
@@ -80,13 +80,13 @@ Returns an `Iterable` for ports in the given range.
 
 Type: `number`
 
-First port of range. Must be in the range `1024...65535`.
+First port of the range. Must be in the range `1024...65535`.
 
 #### to
 
 Type: `number`
 
-Last port of range. Must be in the range `1024...65535` and must be greater than `from`.
+Last port of the range. Must be in the range `1024...65535` and must be greater than `from`.
 
 
 ## Beware

--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ Use `makeRange` helper in case you need to select port from a range to generate 
 ```js
 (async () => {
   console.log(await getPort({port: getPort.makeRange(3000, 3100)}));
-  // Will use any port >= 3000, port < 3100, otherwise fall back to a random port
+  // Will use any port >= 3000, port <= 3100, otherwise fall back to a random port
 })();
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,7 @@ Pass in an array of preferred ports:
 })();
 ```
 
-Use `makeRange` in case you need to select port from a range:
+Use `makeRange` helper in case you need to select port from a range to generate an array of ports:
 
 ```js
 (async () => {

--- a/readme.md
+++ b/readme.md
@@ -43,8 +43,8 @@ Use `makeRange` helper in case you need to select port from a range to generate 
 
 ```js
 (async () => {
-  console.log(await getPort({port: getPort.makeRange(3000, 3003)}));
-  // Will use any port >= 3000, port < 3003, otherwise fall back to a random port
+  console.log(await getPort({port: getPort.makeRange(3000, 3100)}));
+  // Will use any port >= 3000, port < 3100, otherwise fall back to a random port
 })();
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,20 @@ Type: `string`
 
 The host on which port resolution should be performed. Can be either an IPv4 or IPv6 address.
 
+### getPort.makeRange(from, to)
+
+#### from
+
+Type: `number`
+
+Port to start range from, inclusive.
+
+#### to
+
+Type: `number`
+
+Port to end range at, exclusive.
+
 
 ## Beware
 

--- a/test.js
+++ b/test.js
@@ -94,6 +94,18 @@ test('all preferred ports in array are unavailable', async t => {
 	t.not(port, desiredPorts[1]);
 });
 
+test('non-array iterables work', async t => {
+	const desiredPorts = (function * () {
+		yield 9920;
+	})();
+	const port = await getPort({
+		port: desiredPorts,
+		host: '0.0.0.0'
+	});
+
+	t.is(port, 9920);
+});
+
 test('makeRange throws on invalid ranges', t => {
 	t.throws(() => getPort.makeRange(0, 0));
 	t.throws(() => getPort.makeRange(1023, 1023));
@@ -102,6 +114,6 @@ test('makeRange throws on invalid ranges', t => {
 });
 
 test('makeRange produces valid ranges', t => {
-	t.deepEqual(getPort.makeRange(1024, 1025), [1024]);
-	t.deepEqual(getPort.makeRange(1024, 1027), [1024, 1025, 1026]);
+	t.deepEqual([...getPort.makeRange(1024, 1025)], [1024]);
+	t.deepEqual([...getPort.makeRange(1024, 1027)], [1024, 1025, 1026]);
 });

--- a/test.js
+++ b/test.js
@@ -93,3 +93,13 @@ test('all preferred ports in array are unavailable', async t => {
 	t.not(port, desiredPorts[0]);
 	t.not(port, desiredPorts[1]);
 });
+
+test('makeRange', t => {
+	t.throws(() => getPort.makeRange(0, 0));
+	t.throws(() => getPort.makeRange(1024, 1024));
+	t.throws(() => getPort.makeRange(65536, 65536));
+	t.throws(() => getPort.makeRange(1026, 1025));
+
+	t.deepEqual(getPort.makeRange(1025, 1026), [1025]);
+	t.deepEqual(getPort.makeRange(1025, 1028), [1025, 1026, 1027]);
+});

--- a/test.js
+++ b/test.js
@@ -106,12 +106,20 @@ test('non-array iterables work', async t => {
 });
 
 test('makeRange throws on invalid ranges', t => {
-	t.throws(() => getPort.makeRange(1025, 1024));
+	t.throws(() => {
+		getPort.makeRange(1025, 1024);
+	});
 
 	// Invalid port values
-	t.throws(() => getPort.makeRange(0, 0));
-	t.throws(() => getPort.makeRange(1023, 1023));
-	t.throws(() => getPort.makeRange(65536, 65536));
+	t.throws(() => {
+		getPort.makeRange(0, 0);
+	});
+	t.throws(() => {
+		getPort.makeRange(1023, 1023);
+	});
+	t.throws(() => {
+		getPort.makeRange(65536, 65536);
+	});
 });
 
 test('makeRange produces valid ranges', t => {

--- a/test.js
+++ b/test.js
@@ -96,12 +96,12 @@ test('all preferred ports in array are unavailable', async t => {
 
 test('makeRange throws on invalid ranges', t => {
 	t.throws(() => getPort.makeRange(0, 0));
-	t.throws(() => getPort.makeRange(1024, 1024));
+	t.throws(() => getPort.makeRange(1023, 1023));
 	t.throws(() => getPort.makeRange(65536, 65536));
-	t.throws(() => getPort.makeRange(1026, 1025));
+	t.throws(() => getPort.makeRange(1025, 1024));
 });
 
 test('makeRange produces valid ranges', t => {
-	t.deepEqual(getPort.makeRange(1025, 1026), [1025]);
-	t.deepEqual(getPort.makeRange(1025, 1028), [1025, 1026, 1027]);
+	t.deepEqual(getPort.makeRange(1024, 1025), [1024]);
+	t.deepEqual(getPort.makeRange(1024, 1027), [1024, 1025, 1026]);
 });

--- a/test.js
+++ b/test.js
@@ -102,18 +102,20 @@ test('non-array iterables work', async t => {
 		port: desiredPorts,
 		host: '0.0.0.0'
 	});
-
 	t.is(port, 9920);
 });
 
 test('makeRange throws on invalid ranges', t => {
+	t.throws(() => getPort.makeRange(1025, 1024));
+
+	// Invalid port values
 	t.throws(() => getPort.makeRange(0, 0));
 	t.throws(() => getPort.makeRange(1023, 1023));
 	t.throws(() => getPort.makeRange(65536, 65536));
-	t.throws(() => getPort.makeRange(1025, 1024));
 });
 
 test('makeRange produces valid ranges', t => {
-	t.deepEqual([...getPort.makeRange(1024, 1025)], [1024]);
-	t.deepEqual([...getPort.makeRange(1024, 1027)], [1024, 1025, 1026]);
+	t.deepEqual([...getPort.makeRange(1024, 1024)], [1024]);
+	t.deepEqual([...getPort.makeRange(1024, 1025)], [1024, 1025]);
+	t.deepEqual([...getPort.makeRange(1024, 1027)], [1024, 1025, 1026, 1027]);
 });

--- a/test.js
+++ b/test.js
@@ -94,12 +94,14 @@ test('all preferred ports in array are unavailable', async t => {
 	t.not(port, desiredPorts[1]);
 });
 
-test('makeRange', t => {
+test('makeRange throws on invalid ranges', t => {
 	t.throws(() => getPort.makeRange(0, 0));
 	t.throws(() => getPort.makeRange(1024, 1024));
 	t.throws(() => getPort.makeRange(65536, 65536));
 	t.throws(() => getPort.makeRange(1026, 1025));
+});
 
+test('makeRange produces valid ranges', t => {
 	t.deepEqual(getPort.makeRange(1025, 1026), [1025]);
 	t.deepEqual(getPort.makeRange(1025, 1028), [1025, 1026, 1027]);
 });


### PR DESCRIPTION
Fixes #24 

- added makeRange helper (inclusive ranges)
- reworked to use iterables
- errors not concerning us are rethrowed
- prepared for registered ports deprioritization
- bumped node requirement to v8
- removed travis for nodejs v6