### PR TITLE
fix: should work with Node.js 8.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = async options => {
 
 	for (const port of portCheckSequence(ports)) {
 		try {
-			return await getAvailablePort({...options, port}); // eslint-disable-line no-await-in-loop
+			return await getAvailablePort(Object.assign({}, options, {port})); // eslint-disable-line no-await-in-loop
 		} catch (error) {
 			if (error.code !== 'EADDRINUSE') {
 				throw error;


### PR DESCRIPTION
The spread syntax is not supported in Node.js 8.0.0
though the package claims to support Node.js>=8