### PR TITLE
Use "import * as from" instead of require

### DIFF
--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,5 @@
 import {expectType} from 'tsd';
-import getPort = require('.');
+import * as getPort from '.';
 
 expectType<Promise<number>>(getPort());
 expectType<Promise<number>>(getPort({port: 3000}));


### PR DESCRIPTION
Hi, developers. Thank you for your so useful project!

This PR uses **`import * as getPort from '.';`**  because the current `index.test-d.ts` mixed `import` and `require`. I think it's a little bit weird to see mixed `import` and `require`
<https://github.com/sindresorhus/get-port/pull/32/files>

However, this is your preference. You can freely to reject this :D
If you like this style, you could change the release note too:
<https://github.com/sindresorhus/get-port/releases/tag/v5.0.0>.