### PR TITLE
Fix in-process race condition

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const used = {
 	old: new Set(),
 	young: new Set()
 };
+
 const getAvailablePort = options => new Promise((resolve, reject) => {
 	const server = net.createServer();
 	server.unref();
@@ -37,6 +38,7 @@ module.exports = async options => {
 		used.young = new Set();
 	}, sweep);
 	interval.unref();
+
 	for (const port of portCheckSequence(ports)) {
 		try {
 			let p = await getAvailablePort({...options, port}); // eslint-disable-line no-await-in-loop
@@ -49,6 +51,7 @@ module.exports = async options => {
 			}
 
 			used.young.add(p);
+
 			return p;
 		} catch (error) {
 			if (error.code !== 'EADDRINUSE' && error.message !== 'locked') {

--- a/index.js
+++ b/index.js
@@ -17,6 +17,9 @@ const lockedPorts = {
 // and a new young set for locked ports is created
 const releaseOldLockedPortsIntervalMs = 1000 * 15;
 
+// Lazily create interval on first use
+let interval = null;
+
 const getAvailablePort = options => new Promise((resolve, reject) => {
 	const server = net.createServer();
 	server.unref();
@@ -44,12 +47,14 @@ module.exports = async options => {
 		ports = typeof options.port === 'number' ? [options.port] : options.port;
 	}
 
-	const interval = setInterval(() => {
-		lockedPorts.old = lockedPorts.young;
-		lockedPorts.young = new Set();
-	}, releaseOldLockedPortsIntervalMs);
+	if (interval === null) {
+		interval = setInterval(() => {
+			lockedPorts.old = lockedPorts.young;
+			lockedPorts.young = new Set();
+		}, releaseOldLockedPortsIntervalMs);
 
-	interval.unref();
+		interval.unref();
+	}
 
 	for (const port of portCheckSequence(ports)) {
 		try {

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ module.exports = async options => {
 	const interval = setInterval(() => {
 		used.old = used.young;
 		used.young = new Set();
-	}, sweep);
+	}, sweep).unref();
 	interval.unref();
 
 	for (const port of portCheckSequence(ports)) {

--- a/readme.md
+++ b/readme.md
@@ -93,6 +93,8 @@ Last port of the range. Must be in the range `1024`...`65535` and must be greate
 
 There is a very tiny chance of a race condition if another service starts using the same port number as you in between the time you get the port number and you actually start using it.
 
+Race conditions in the same service are mitigated against by using a light weight locking mechanism where a port will be held for a minimum of 15 seconds and a maximum of 30 seconds before being released again. This a scenario where the same port can be returned when rapidly getting lots of ports numbers, which is again linked to getting the port number and actually using it.
+
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -91,9 +91,9 @@ Last port of the range. Must be in the range `1024`...`65535` and must be greate
 
 ## Beware
 
-There is a very tiny chance of a race condition if another service starts using the same port number as you in between the time you get the port number and you actually start using it.
+There is a very tiny chance of a race condition if another process starts using the same port number as you in between the time you get the port number and you actually start using it.
 
-Race conditions in the same service are mitigated against by using a light weight locking mechanism where a port will be held for a minimum of 15 seconds and a maximum of 30 seconds before being released again. This a scenario where the same port can be returned when rapidly getting lots of ports numbers, which is again linked to getting the port number and actually using it.
+Race conditions in the same process are mitigated against by using a lightweight locking mechanism where a port will be held for a minimum of 15 seconds and a maximum of 30 seconds before being released again.
 
 
 ## Related

--- a/test.js
+++ b/test.js
@@ -129,24 +129,18 @@ test('makeRange produces valid ranges', t => {
 });
 
 test('ports are locked for up to 30 seconds', async t => {
-	// Speed up the test by overriding setInterval:
+	// Speed up the test by overriding `setInterval`.
 	const {setInterval} = global;
-	global.setInterval = (fn, timeout) => {
-		return setInterval(fn, timeout / 100);
-	};
+	global.setInterval = (fn, timeout) => setInterval(fn, timeout / 100);
 
 	delete require.cache[require.resolve('.')];
 	const getPort = require('.');
 	const timeout = promisify(setTimeout);
 	const port = await getPort();
-	const port2 = await getPort({
-		port
-	});
+	const port2 = await getPort({port});
 	t.not(port2, port);
 	await timeout(300); // 30000 / 100
-	const port3 = await getPort({
-		port
-	});
+	const port3 = await getPort({port});
 	t.is(port3, port);
 	global.setInterval = setInterval;
 });

--- a/test.js
+++ b/test.js
@@ -44,7 +44,7 @@ test('port can be bound to IPv4 host when promise resolves', async t => {
 });
 
 test('preferred port given IPv4 host', async t => {
-	const desiredPort = 8080;
+	const desiredPort = 8081;
 	const port = await getPort({
 		port: desiredPort,
 		host: '0.0.0.0'


### PR DESCRIPTION
This is related to https://github.com/sindresorhus/get-port/issues/23 but it's doesn't solve the multiprocess race condition. 

This might have only started occurring in later node versions, but when calling `get-port` a lot sometimes the same port will be returned and then port already bound error occurs when trying to bind to it. 

You can extend this to solve #23 by replacing `Set` with an ondisk store (maybe leveldb?).

The reason for using an old/young sets approach is to avoid setting one interval per port (which would be overkill imo) while also ensuring that a port isn't forgotten for _at least_ the `sweep` time, but up to double the `sweep` time. 