### PR TITLE
Fall back to a random port if preferred port is privileged

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ module.exports = async options => {
 		try {
 			return await getAvailablePort({...options, port}); // eslint-disable-line no-await-in-loop
 		} catch (error) {
-			if (error.code !== 'EADDRINUSE') {
+			if (!['EADDRINUSE', 'EACCES'].includes(error.code)) {
 				throw error;
 			}
 		}

--- a/test.js
+++ b/test.js
@@ -32,6 +32,15 @@ test('preferred port unavailable', async t => {
 	t.not(port, desiredPort);
 });
 
+test('preferred port priviliged', async t => {
+	const desiredPort = 80;
+	const port = await getPort({host: '127.0.0.1', port: desiredPort});
+
+	t.is(typeof port, 'number');
+	t.true(port > 0);
+	t.not(port, desiredPort);
+});
+
 test('port can be bound to IPv4 host when promise resolves', async t => {
 	const port = await getPort({host: '0.0.0.0'});
 	t.is(typeof port, 'number');

--- a/test.js
+++ b/test.js
@@ -32,7 +32,7 @@ test('preferred port unavailable', async t => {
 	t.not(port, desiredPort);
 });
 
-test('preferred port priviliged', async t => {
+test('preferred port privileged', async t => {
 	const desiredPort = 80;
 	const port = await getPort({host: '127.0.0.1', port: desiredPort});
 


### PR DESCRIPTION
Note that the test is using `127.0.0.1` so that it can run on MacOS, which stopped enforcing privileged ports in `10.14` and later, see https://news.ycombinator.com/item?id=18302380. Unfortunately, it's possible this is a bug and that Apple could fix it in the future, but test still passes as of MacOS `10.15.2`. The test will also fail if run as root on Linux, but I don't think they should typically be running as root. If anyone has any better ideas, please do suggest!

Closes #38