### PR TITLE
Fix unref'ing the timer in some environments

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ module.exports = async options => {
 		if (interval.unref) {
 			interval.unref();
 		} else {
-			console.warn('It looks like you are using Jest with `jsdom` env. Please swith to `jest-environment-node`. Details: https://github.com/facebook/jest/issues/9033');
+			console.warn('It looks like you are using Jest with `jsdom` env. Please run via `jest --env node` command. Details: https://github.com/facebook/jest/issues/9033');
 		}
 	}
 

--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ module.exports = async options => {
 		if (interval.unref) {
 			interval.unref();
 		} else {
-			console.warn("It's look like you are using Jest with `jsdom` env. Please swith to `jest-environment-node`. Details: https://github.com/facebook/jest/issues/9033");
+			console.warn('It looks like you are using Jest with `jsdom` env. Please swith to `jest-environment-node`. Details: https://github.com/facebook/jest/issues/9033');
 		}
 	}
 

--- a/index.js
+++ b/index.js
@@ -54,8 +54,9 @@ module.exports = async options => {
 		}, releaseOldLockedPortsIntervalMs);
 
 		if (interval.unref) {
-			// fix for https://github.com/facebook/jest/issues/9033
 			interval.unref();
+		} else {
+			console.warn("It's look like you are using Jest with `jsdom` env. Please swith to `jest-environment-node`. Details: https://github.com/facebook/jest/issues/9033");
 		}
 	}
 

--- a/index.js
+++ b/index.js
@@ -53,10 +53,9 @@ module.exports = async options => {
 			lockedPorts.young = new Set();
 		}, releaseOldLockedPortsIntervalMs);
 
+		// Method `interval.unref` may not exists (eg. in electron, jest jsdom env, and other "browser" environments) 
 		if (interval.unref) {
 			interval.unref();
-		} else {
-			console.warn('It looks like you are using Jest with `jsdom` env. Please run via `jest --env node` command. Details: https://github.com/facebook/jest/issues/9033');
 		}
 	}
 

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ module.exports = async options => {
 			lockedPorts.young = new Set();
 		}, releaseOldLockedPortsIntervalMs);
 
-		// Method `interval.unref` may not exists (eg. in electron, jest jsdom env, and other "browser" environments) 
+		// Method `interval.unref` may not exists (eg. in electron, jest jsdom env, and other "browser" environments).
 		if (interval.unref) {
 			interval.unref();
 		}

--- a/index.js
+++ b/index.js
@@ -53,7 +53,10 @@ module.exports = async options => {
 			lockedPorts.young = new Set();
 		}, releaseOldLockedPortsIntervalMs);
 
-		if (interval.unref) interval.unref();
+		if (interval.unref) {
+			// fix for https://github.com/facebook/jest/issues/9033
+			interval.unref();
+		}
 	}
 
 	for (const port of portCheckSequence(ports)) {

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ module.exports = async options => {
 			lockedPorts.young = new Set();
 		}, releaseOldLockedPortsIntervalMs);
 
-		// Method `interval.unref` may not exists (eg. in electron, jest jsdom env, and other "browser" environments).
+		// Does not exist in some environments (Electron, Jest jsdom env, browser, etc).
 		if (interval.unref) {
 			interval.unref();
 		}

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ module.exports = async options => {
 			lockedPorts.young = new Set();
 		}, releaseOldLockedPortsIntervalMs);
 
-		interval.unref();
+		if (interval.unref) interval.unref();
 	}
 
 	for (const port of portCheckSequence(ports)) {


### PR DESCRIPTION
It very strange but in some cases thrown "Error: interval.unref is not a function" in 5.1.0.

Error is thrown in line 56:

https://github.com/sindresorhus/get-port/blob/0edd17a5eb7ab8a02342c9defb0f622621a03e47/index.js#L50-L57

If we change code to
```if(interval.unref) interval.unref();```

Then the error disappears.