### PR TITLE
Always use the node version of setInterval

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 const net = require('net');
-const { setInterval } = require('timers');
+const {setInterval} = require('timers');
 
 class Locked extends Error {
 	constructor(port) {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 const net = require('net');
+const { setInterval } = require('timers');
 
 class Locked extends Error {
 	constructor(port) {


### PR DESCRIPTION
Using `get-port` in electron with `nodeIntegration: true` will fail because the blink version of `setInterval` gets used in the renderer process instead of the Node.js implementation. The following error is reported: `setInterval(...).unref is not a function`.

I added an explicit require for `setInterval` as the following comment suggested:
https://github.com/electron/electron/issues/21162#issuecomment-554792447