### PR TITLE
Set the default port

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ const getAvailablePort = options => new Promise((resolve, reject) => {
 	const server = net.createServer();
 	server.unref();
 	server.on('error', reject);
-	server.listen(options, () => {
+	server.listen({ host: '127.0.0.1', ...options }, () => {
 		const {port} = server.address();
 		server.close(() => {
 			resolve(port);


### PR DESCRIPTION
I tested it according to the Readme and found it not work:

```js
(async () => {
  console.log(await getPort({ port: 2003 }))
})();
```

Then I check the issue,and found that the host option is required

I think a default port should be set. This way, users will not be confused when using according to the readme