### PR TITLE
fix get-port

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,16 +53,22 @@ const testPortForHosts = async (options, hosts) => {
 		return getAvailablePort(options);
 	}
 
-	for (const host of hosts) {
+	let index = 0;
+
+	while (index < hosts.length) {
+		const host = hosts[index];
 		try {
 			await getAvailablePort({port: options.port, host}); // eslint-disable-line no-await-in-loop
 		} catch (error) {
 			if (['EADDRNOTAVAIL', 'EINVAL'].includes(error.code)) {
 				hosts.splice(hosts.indexOf(host), 1);
+				continue;
 			} else {
 				throw error;
 			}
 		}
+
+		++index;
 	}
 
 	return options.port;

--- a/index.js
+++ b/index.js
@@ -22,27 +22,7 @@ const releaseOldLockedPortsIntervalMs = 1000 * 15;
 let interval;
 
 const getHosts = () => {
-	let interfaces = {};
-	try {
-		interfaces = os.networkInterfaces();
-	} catch (error) {
-		// As of October 2016, Windows Subsystem for Linux (WSL) does not support
-		// the os.networkInterfaces() call and throws instead. For this platform,
-		// assume 0.0.0.0 as the only address
-		//
-		// - https://github.com/Microsoft/BashOnWindows/issues/468
-		//
-		// - Workaround is a mix of good work from the community:
-		//   - https://github.com/http-party/node-portfinder/commit/8d7e30a648ff5034186551fa8a6652669dec2f2f
-		//   - https://github.com/yarnpkg/yarn/pull/772/files
-		if (error.syscall === 'uv_interface_addresses') {
-			// Swallow error because we're just going to use defaults
-			// documented @ https://github.com/nodejs/node/blob/4b65a65e75f48ff447cabd5500ce115fb5ad4c57/doc/api/net.md#L231
-		} else {
-			throw error;
-		}
-	}
-
+	const interfaces = os.networkInterfaces();
 	const results = [];
 
 	for (const _interface of Object.values(interfaces)) {

--- a/test.js
+++ b/test.js
@@ -153,3 +153,20 @@ test('ports are locked for up to 30 seconds', async t => {
 	t.is(port3, port);
 	global.setInterval = setInterval;
 });
+
+const boundPort = async ({port, host}) => {
+	const server = net.createServer();
+	await promisify(server.listen.bind(server))({port, host});
+	return server;
+};
+
+test('preferred ports is bound up with different hosts', async t => {
+	const desiredPorts = [10990, 10991, 10992];
+
+	await boundPort({port: desiredPorts[0], host: '::'});
+	await boundPort({port: desiredPorts[1], host: '127.0.0.1'});
+
+	const port = await getPort({port: desiredPorts});
+
+	t.is(port, desiredPorts[2]);
+});


### PR DESCRIPTION
get-port doesn't check port availability for all hosts in some environments, so it return port that already in use

i fix that with next steps:

- get all existed hosts by `os.networkInterfaces()`
- check port with this hosts
- some hosts can't be used for user land servers and throws `EADDRNOTAVAIL` on mac or `EINVAL` on linux, so i remove them for all next tests
