### PR TITLE
Check all local hosts for port availability

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,10 +5,14 @@ on:
 jobs:
   test:
     name: Node.js ${{ matrix.node-version }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
         node-version:
           - 14
           - 12

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on:
   - pull_request
 jobs:
   test:
-    name: Node.js ${{ matrix.node-version }}
+    name: Node.js ${{ matrix.node-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/index.js
+++ b/index.js
@@ -31,7 +31,8 @@ const getHosts = () => {
 		}
 	}
 
-	// Add undefined value, for createServer function, do not use host and default 0.0.0.0 host
+	// Add undefined value for createServer function to use default host,
+	// and default IPv4 host in case createServer defaults to IPv6.
 	return results.concat(undefined, '0.0.0.0');
 };
 

--- a/index.js
+++ b/index.js
@@ -54,23 +54,14 @@ const getAvailablePort = async (options, hosts) => {
 		return checkAvailablePort(options);
 	}
 
-	let index = 0;
-	const hostsCopy = [...hosts];
-
-	while (index < hostsCopy.length) {
-		const host = hostsCopy[index];
+	for (const host of hosts) {
 		try {
 			await checkAvailablePort({port: options.port, host}); // eslint-disable-line no-await-in-loop
 		} catch (error) {
-			if (['EADDRNOTAVAIL', 'EINVAL'].includes(error.code)) {
-				hostsCopy.splice(hostsCopy.indexOf(host), 1);
-				continue;
-			} else {
+			if (!['EADDRNOTAVAIL', 'EINVAL'].includes(error.code)) {
 				throw error;
 			}
 		}
-
-		++index;
 	}
 
 	return options.port;

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ const releaseOldLockedPortsIntervalMs = 1000 * 15;
 // Lazily create interval on first use
 let interval;
 
-const getHosts = () => {
+const getLocalHosts = () => {
 	const interfaces = os.networkInterfaces();
 	const results = [];
 
@@ -94,7 +94,7 @@ module.exports = async options => {
 		}
 	}
 
-	const hosts = getHosts();
+	const hosts = getLocalHosts();
 
 	for (const port of portCheckSequence(ports)) {
 		try {

--- a/index.js
+++ b/index.js
@@ -23,17 +23,20 @@ let interval;
 
 const getLocalHosts = () => {
 	const interfaces = os.networkInterfaces();
-	const results = [];
+	const results = new Set();
 
 	for (const _interface of Object.values(interfaces)) {
 		for (const config of _interface) {
-			results.push(config.address);
+			results.add(config.address);
 		}
 	}
 
 	// Add undefined value for createServer function to use default host,
 	// and default IPv4 host in case createServer defaults to IPv6.
-	return results.concat(undefined, '0.0.0.0');
+	results.add(undefined);
+	results.add('0.0.0.0');
+
+	return results;
 };
 
 const checkAvailablePort = options =>

--- a/index.js
+++ b/index.js
@@ -25,7 +25,8 @@ const getAvailablePort = options => new Promise((resolve, reject) => {
 	server.unref();
 	server.on('error', reject);
 	server.listen(options, () => {
-		const {port} = server.address();
+		const {port, address, family} = server.address();
+		console.log(port, address, family);
 		server.close(() => {
 			resolve(port);
 		});

--- a/index.js
+++ b/index.js
@@ -23,18 +23,15 @@ let interval;
 
 const getLocalHosts = () => {
 	const interfaces = os.networkInterfaces();
-	const results = new Set();
+	// Add undefined value for createServer function to use default host,
+	// and default IPv4 host in case createServer defaults to IPv6.
+	const results = new Set([undefined, '0.0.0.0']);
 
 	for (const _interface of Object.values(interfaces)) {
 		for (const config of _interface) {
 			results.add(config.address);
 		}
 	}
-
-	// Add undefined value for createServer function to use default host,
-	// and default IPv4 host in case createServer defaults to IPv6.
-	results.add(undefined);
-	results.add('0.0.0.0');
 
 	return results;
 };

--- a/index.js
+++ b/index.js
@@ -25,8 +25,7 @@ const getAvailablePort = options => new Promise((resolve, reject) => {
 	server.unref();
 	server.on('error', reject);
 	server.listen(options, () => {
-		const {port, address, family} = server.address();
-		console.log(port, address, family);
+		const {port} = server.address();
 		server.close(() => {
 			resolve(port);
 		});

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,8 @@
 # get-port
 
-> Get an available [TCP port](https://en.wikipedia.org/wiki/Port_(computer_networking))
+> Get an available [TCP port](https://en.wikipedia.org/wiki/Port_(computer_networking)).
+>
+> Checks availability on all local addresses defined in [OS network interfaces](https://nodejs.org/api/os.html#os_os_networkinterfaces).
 
 ## Install
 

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 > Get an available [TCP port](https://en.wikipedia.org/wiki/Port_(computer_networking)).
 >
-> Checks availability on all local addresses defined in [OS network interfaces](https://nodejs.org/api/os.html#os_os_networkinterfaces).
+>
 
 ## Install
 
@@ -69,6 +69,8 @@ A preferred port or an iterable of preferred ports to use.
 Type: `string`
 
 The host on which port resolution should be performed. Can be either an IPv4 or IPv6 address.
+
+By default, `get-port` checks availability on all local addresses defined in [OS network interfaces](https://nodejs.org/api/os.html#os_os_networkinterfaces). If this option is set, it will only check the specified host.
 
 ### getPort.makeRange(from, to)
 

--- a/test.js
+++ b/test.js
@@ -164,7 +164,7 @@ test('preferred ports is bound up with different hosts', async t => {
 	const desiredPorts = [10990, 10991, 10992, 10993];
 
 	await bindPort({port: desiredPorts[0]});
-	await bindPort({port: desiredPorts[1], host: '::'});
+	await bindPort({port: desiredPorts[1], host: '0.0.0.0'});
 	await bindPort({port: desiredPorts[2], host: '127.0.0.1'});
 
 	const port = await getPort({port: desiredPorts});

--- a/test.js
+++ b/test.js
@@ -153,3 +153,21 @@ test('ports are locked for up to 30 seconds', async t => {
 	t.is(port3, port);
 	global.setInterval = setInterval;
 });
+
+const bindPort = async ({port, host}) => {
+	const server = net.createServer();
+	await promisify(server.listen.bind(server))({port, host});
+	return server;
+};
+
+test('preferred ports is bound up with different hosts', async t => {
+	const desiredPorts = [10990, 10991, 10992, 10993];
+
+	await bindPort({port: desiredPorts[0]});
+	await bindPort({port: desiredPorts[1], host: '::'});
+	await bindPort({port: desiredPorts[2], host: '127.0.0.1'});
+
+	const port = await getPort({port: desiredPorts});
+
+	t.is(port, desiredPorts[3]);
+});


### PR DESCRIPTION
Should fix #31 and fix #48.

Note that the solution is copied from #52, with some comments resolved that were not fixed in that PR. Decided to file a new one, because #52 hasn't been updated in months and I would like to get this resolved - lately there have been more and more reports of the "automatic port selection" not working in several projects.

Answering some comments here:
> I would have liked to see more comprehensive testing than a single assertion.

Not sure how to test this "more comprehensively". I "resolved" this comment by making the tests run in CI on macos and windows, too, where the added test failed without the fix (see [this](https://github.com/mihkeleidast/get-port/actions/runs/1108024292) run). This makes sense to me, because networking and port allocation seem to depend on the operating system. There are however some issues with the 30s test on macos (it _sometimes_ fails), not sure how to fix that?

> Are you sure that's a get-port bug and not a Node.js bug? Just want to ensure we don't fix this in the wrong place.

To me it seems like an issue with how get-port checks port availability, and not how Node's net module works. But to be fair I cannot wrap my brain around how networking and port locking works, so :) The fix seems to work, however, at least in tests.