### PR TITLE
Use timeout instead of interval for releasing ports

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,8 +20,8 @@ const releaseOldLockedPortsIntervalMs = 1000 * 15;
 const minPort = 1024;
 const maxPort = 65_535;
 
-// Lazily create interval on first use
-let interval;
+// Lazily create timeout on first use
+let timeout;
 
 const getLocalHosts = () => {
 	const interfaces = os.networkInterfaces();
@@ -109,15 +109,17 @@ export default async function getPorts(options) {
 		}
 	}
 
-	if (interval === undefined) {
-		interval = setInterval(() => {
+	if (timeout === undefined) {
+		timeout = setTimeout(() => {
+			timeout = undefined;
+
 			lockedPorts.old = lockedPorts.young;
 			lockedPorts.young = new Set();
 		}, releaseOldLockedPortsIntervalMs);
 
 		// Does not exist in some environments (Electron, Jest jsdom env, browser, etc).
-		if (interval.unref) {
-			interval.unref();
+		if (timeout.unref) {
+			timeout.unref();
 		}
 	}
 


### PR DESCRIPTION
fixes #45

This PR switches from `setInterval()` to `setTimeout()`. It'll make sure that there isn't a timer running forever. Every time `getPorts()` is called, the timer is re-created.

I hope this logic is correct 🙈 