### PR TITLE
Update type import syntax to fix TS <4.5 compatibility

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import {type ListenOptions} from 'node:net';
+import type {ListenOptions} from 'node:net';
 
 export type Options = {
 	/**


### PR DESCRIPTION
I'm using this module in a monorepo where TypeScript gets resolved to a lower version than v4.5 in some packages. The syntax introduced in v7 is not compatible with these versions. This is a straightforward fix.

See: https://www.typescriptlang.org/docs/handbook/modules.html#importing-types